### PR TITLE
Fix: Replace npm ci with npm install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install app dependencies
-RUN npm ci
+RUN npm install
 
 # Bundle app source
 COPY . .


### PR DESCRIPTION
## Fix for npm ci error

This PR fixes the Docker build error:
```
npm error code EUSAGE
npm error The `npm ci` command can only install with an existing package-lock.json
```

### Changes
- Changed `npm ci` to `npm install` in the Dockerfile
- This allows the build to proceed without requiring a package-lock.json file

### Why this approach?
Rather than generating and committing a package-lock.json file (which would need to be maintained), this change makes the build process more flexible by using the standard `npm install` command which doesn't require a lock file.

The Dockerfile will now work reliably on Railway and in other deployment contexts regardless of whether a package-lock.json file exists.
